### PR TITLE
Improvements

### DIFF
--- a/hr_timesheet_rounded/models/account_analytic_line.py
+++ b/hr_timesheet_rounded/models/account_analytic_line.py
@@ -74,7 +74,7 @@ class AccountAnalyticLine(models.Model):
     # ORM Overrides
     ####################################################
     @api.model
-    def read_group(self, domain, fields, groupby, offset=0,
+    def read_group(self, domain, fields_list, groupby, offset=0,
                    limit=None, orderby=False, lazy=True):
         """Replace the value of unit_amount by unit_amount_rounded.
 
@@ -84,11 +84,12 @@ class AccountAnalyticLine(models.Model):
         which in turns compute the delivered qty on SO line.
         """
         ctx_ts_rounded = self.env.context.get('timesheet_rounding')
+        fields_local = fields_list.copy() if fields_list else []
         if ctx_ts_rounded:
             # To add the unit_amount_rounded value on read_group
-            fields.append('unit_amount_rounded')
+            fields_local.append('unit_amount_rounded')
         res = super().read_group(
-            domain, fields, groupby, offset=offset,
+            domain, fields_local, groupby, offset=offset,
             limit=limit, orderby=orderby, lazy=lazy
         )
         if ctx_ts_rounded:
@@ -97,7 +98,7 @@ class AccountAnalyticLine(models.Model):
                 rec['unit_amount'] = rec['unit_amount_rounded']
         return res
 
-    def read(self, fields=None, load='_classic_read'):
+    def read(self, fields_list=None, load='_classic_read'):
         """Replace the value of unit_amount by unit_amount_rounded.
 
         When context key `timesheet_rounding` is True
@@ -105,7 +106,7 @@ class AccountAnalyticLine(models.Model):
         This affects `account_anaytic_line._sale_determine_order_line`.
         """
         ctx_ts_rounded = self.env.context.get('timesheet_rounding')
-        fields_local = fields.copy() if fields else []
+        fields_local = fields_list.copy() if fields_list else []
         read_unit_amount = 'unit_amount' in fields_local or not fields_local
         if ctx_ts_rounded and read_unit_amount and fields_local:
             if 'unit_amount_rounded' not in fields_local:

--- a/hr_timesheet_rounded/models/account_analytic_line.py
+++ b/hr_timesheet_rounded/models/account_analytic_line.py
@@ -39,19 +39,19 @@ class AccountAnalyticLine(models.Model):
                 # already set, no forcing: do nothing
                 continue
             rec.unit_amount_rounded = self._calc_rounded_amount(
-                rec.project_id.timesheet_rounding_granularity,
+                rec.project_id.timesheet_rounding_unit,
                 rec.project_id.timesheet_rounding_method,
-                rec.project_id.timesheet_invoicing_factor,
+                rec.project_id.timesheet_rounding_factor,
                 rec.unit_amount,
             )
 
     @staticmethod
-    def _calc_rounded_amount(granularity, rounding_method, factor, amount):
+    def _calc_rounded_amount(rounding_unit, rounding_method, factor, amount):
         factor = factor / 100.0
-        if granularity:
+        if rounding_unit:
             unit_amount_rounded = float_round(
                 amount * factor,
-                precision_rounding=granularity,
+                precision_rounding=rounding_unit,
                 rounding_method=rounding_method
             )
         else:

--- a/hr_timesheet_rounded/models/project_project.py
+++ b/hr_timesheet_rounded/models/project_project.py
@@ -7,8 +7,8 @@ class ProjectProject(models.Model):
 
     _inherit = 'project.project'
 
-    timesheet_rounding_granularity = fields.Float(
-        string='Timesheet rounding granularity',
+    timesheet_rounding_unit = fields.Float(
+        string='Timesheet rounding unit',
         default=0.0,
         help="""1.0 = hour
             0.25 = 15 min
@@ -26,17 +26,17 @@ class ProjectProject(models.Model):
         default='UP',
         required=True
     )
-    timesheet_invoicing_factor = fields.Float(
-        string='Timesheet invoicing factor in percentage',
+    timesheet_rounding_factor = fields.Float(
+        string='Timesheet rounding factor in percentage',
         default=100.0
     )
 
     _sql_constraints = [
         (
-            'check_timesheet_invoicing_factor',
-            'CHECK(0 <= timesheet_invoicing_factor '
-            'AND timesheet_invoicing_factor <= 500)',
-            'Timesheet invoicing factor should stay between 0 and 500,'
+            'check_timesheet_rounding_factor',
+            'CHECK(0 <= timesheet_rounding_factor '
+            'AND timesheet_rounding_factor <= 500)',
+            'Timesheet rounding factor should stay between 0 and 500,'
             ' endpoints included.'
         )
     ]

--- a/hr_timesheet_rounded/readme/CONFIGURE.rst
+++ b/hr_timesheet_rounded/readme/CONFIGURE.rst
@@ -1,7 +1,7 @@
 Go to a project and set the following fields according to your needs:
 
 
-* Timesheet rounding granularity
+* Timesheet rounding unit
 
 Defines the rounding unit.
 For instance, if you want to round to 1 hour, you can set `1.0`.
@@ -15,6 +15,10 @@ Options: "Closest", "Up" (default).
 Please refer to `odoo.tools.float_utils.float_round` to understand the difference.
 
 
-* Timesheet invoicing factor in percentage
+* Timesheet rounding factor (percentage)
 
-When granularity is not defined you can round by a fixed %.
+When round unit is not defined you can round by a fixed %.
+
+When using both a factor and a percentage, the percentage will be applied first:
+
+  result = round(amount * percentage, unit)

--- a/hr_timesheet_rounded/readme/CONFIGURE.rst
+++ b/hr_timesheet_rounded/readme/CONFIGURE.rst
@@ -10,7 +10,7 @@ If you want to round to 15 min set `0.25`.
 
 * Timesheet rounding method
 
-Options: "Closest", "Up" (default).
+Options: "Closest", "Up" (default), "Down".
 
 Please refer to `odoo.tools.float_utils.float_round` to understand the difference.
 
@@ -19,6 +19,7 @@ Please refer to `odoo.tools.float_utils.float_round` to understand the differenc
 
 When round unit is not defined you can round by a fixed %.
 
-When using both a factor and a percentage, the percentage will be applied first:
+
+When using both a unit and a factor, the factor will be applied first:
 
   result = round(amount * percentage, unit)

--- a/hr_timesheet_rounded/readme/DESCRIPTION.rst
+++ b/hr_timesheet_rounded/readme/DESCRIPTION.rst
@@ -1,8 +1,8 @@
-Round timesheet lines quantity based on project' settings.
+Round timesheet lines amounts in sales based on project' settings.
 
 A typical use case is: you work 5 minutes but you want to invoice 15 minutes.
 
-With this module you can configure a rounding factor on the project
+With this module you can configure a rounding unit or factor on the project
 and all the lines tracked on this project's tasks will show a rounded amount.
 
 If you want you can override the value manually on each entry.
@@ -11,4 +11,3 @@ The delivered quantity on the sale order line
 - and by consequence on the invoice - will be computed using the rounded amount.
 
 Expense lines and other non-timesheet lines won't be affected.
-

--- a/hr_timesheet_rounded/tests/test_rounded.py
+++ b/hr_timesheet_rounded/tests/test_rounded.py
@@ -34,9 +34,9 @@ class TestRounded(TestCommonSaleTimesheetNoChart):
         sale_order_line.product_id_change()
         cls.sale_order.action_confirm()
         cls.project_global.write({
-            'timesheet_rounding_granularity': 0.25,
+            'timesheet_rounding_unit': 0.25,
             'timesheet_rounding_method': 'UP',
-            'timesheet_invoicing_factor': 200,
+            'timesheet_rounding_factor': 200,
         })
         cls.product_expense = cls.env['product.product'].create({
             'name': "Service delivered, EXPENSE",
@@ -68,8 +68,8 @@ class TestRounded(TestCommonSaleTimesheetNoChart):
 
     def test_analytic_line_create_no_rounding(self):
         self.project_global.write({
-            'timesheet_rounding_granularity': False,
-            'timesheet_invoicing_factor': False,
+            'timesheet_rounding_unit': False,
+            'timesheet_rounding_factor': False,
         })
         # no rounding enabled
         line = self.create_analytic_line(unit_amount=1)
@@ -181,9 +181,9 @@ class TestRounded(TestCommonSaleTimesheetNoChart):
     def test_sale_order_qty_3(self):
         # amount=0.9
         # should be rounded to 2 by the invoicing_factor with the project
-        # timesheet_rounding_granularity: 0.25
+        # timesheet_rounding_unit: 0.25
         # timesheet_rounding_method: 'UP'
-        # timesheet_invoicing_factor: 200
+        # timesheet_rounding_factor: 200
         self.create_analytic_line(unit_amount=0.9)
         self.assertAlmostEqual(self.sale_order.order_line.qty_delivered, 2.0)
         self.assertAlmostEqual(self.sale_order.order_line.qty_to_invoice, 2.0)
@@ -192,10 +192,10 @@ class TestRounded(TestCommonSaleTimesheetNoChart):
     def test_sale_order_qty_4(self):
         # amount=0.9
         # should be rounded to 2 by the invoicing_factor with the project
-        # timesheet_rounding_granularity: 0.25
+        # timesheet_rounding_unit: 0.25
         # timesheet_rounding_method: 'UP'
-        # timesheet_invoicing_factor: 200
-        self.project_global.timesheet_invoicing_factor = 400
+        # timesheet_rounding_factor: 200
+        self.project_global.timesheet_rounding_factor = 400
         self.create_analytic_line(unit_amount=1.0)
         self.assertAlmostEqual(self.sale_order.order_line.qty_delivered, 4.0)
         self.assertAlmostEqual(self.sale_order.order_line.qty_to_invoice, 4.0)
@@ -203,61 +203,61 @@ class TestRounded(TestCommonSaleTimesheetNoChart):
 
     def test_calc_rounded_amount_method(self):
         aal = self.env['account.analytic.line']
-        granularity = 0.25
+        rounding_unit = 0.25
         rounding_method = 'UP'
         factor = 200
         amount = 1
         self.assertEqual(
             aal._calc_rounded_amount(
-                granularity, rounding_method, factor, amount
+                rounding_unit, rounding_method, factor, amount
             ), 2)
 
-        granularity = 0.0
+        rounding_unit = 0.0
         rounding_method = 'UP'
         factor = 200
         amount = 1
         self.assertEqual(
             aal._calc_rounded_amount(
-                granularity, rounding_method, factor, amount
+                rounding_unit, rounding_method, factor, amount
             ), 2
         )
 
-        granularity = 0.25
+        rounding_unit = 0.25
         rounding_method = 'UP'
         factor = 100
         amount = 1.0
         self.assertEqual(
             aal._calc_rounded_amount(
-                granularity, rounding_method, factor, amount
+                rounding_unit, rounding_method, factor, amount
             ), 1
         )
 
-        granularity = 0.25
+        rounding_unit = 0.25
         rounding_method = 'UP'
         factor = 200
         amount = 0.9
         self.assertEqual(
             aal._calc_rounded_amount(
-                granularity, rounding_method, factor, amount
+                rounding_unit, rounding_method, factor, amount
             ), 2
         )
 
-        granularity = 1.0
+        rounding_unit = 1.0
         rounding_method = 'UP'
         factor = 200
         amount = 0.6
         self.assertEqual(
             aal._calc_rounded_amount(
-                granularity, rounding_method, factor, amount
+                rounding_unit, rounding_method, factor, amount
             ), 2
         )
 
-        granularity = 0.25
+        rounding_unit = 0.25
         rounding_method = 'HALF_UP'
         factor = 200
         amount = 1.01
         self.assertEqual(
             aal._calc_rounded_amount(
-                granularity, rounding_method, factor, amount
+                rounding_unit, rounding_method, factor, amount
             ), 2
         )

--- a/hr_timesheet_rounded/tests/test_rounded.py
+++ b/hr_timesheet_rounded/tests/test_rounded.py
@@ -18,7 +18,7 @@ class TestRounded(TestCommonSaleTimesheetNoChart):
         cls.setUpEmployees()
         cls.setUpServiceProducts()
         cls.sale_order = cls.env['sale.order'].create({
-            # 'analytic_account_id': cls.project_global.analytic_account_id.id,
+            'analytic_account_id': cls.project_global.analytic_account_id.id,
             'partner_id': cls.partner_customer_usd.id,
             'partner_invoice_id': cls.partner_customer_usd.id,
             'partner_shipping_id': cls.partner_customer_usd.id,
@@ -97,20 +97,30 @@ class TestRounded(TestCommonSaleTimesheetNoChart):
         # without context the unit_amount should be the inital
         # with the context the value of unit_amount should be replace by the
         # unit_amount_rounded
-        line = self.create_analytic_line(unit_amount=1)
+        line = self.env['account.analytic.line']
+        self.create_analytic_line(unit_amount=1)
         domain = [('project_id', '=', self.project_global.id)]
-        fields = ['so_line', 'unit_amount', 'product_uom_id']
+        fields_list = ['so_line', 'unit_amount', 'product_uom_id']
         groupby = ['product_uom_id', 'so_line']
 
-        data_ctx_f = line.with_context(timesheet_rounding=False).read_group(
-            domain, fields, groupby,
-        )
+        data_ctx_f = line.read_group(domain, fields_list, groupby,)
         self.assertEqual(data_ctx_f[0]['unit_amount'], 1.0)
 
         data_ctx_t = line.with_context(timesheet_rounding=True).read_group(
-            domain, fields, groupby,
+            domain, fields_list, groupby,
         )
         self.assertEqual(data_ctx_t[0]['unit_amount'], 2.0)
+
+        self.create_analytic_line(unit_amount=1.1)
+        data_ctx_f = line.with_context(timesheet_rounding=False).read_group(
+            domain, fields_list, groupby,
+        )
+        self.assertEqual(data_ctx_f[0]['unit_amount'], 2.1)
+
+        data_ctx_f = line.with_context(timesheet_rounding=True).read_group(
+            domain, fields_list, groupby,
+        )
+        self.assertEqual(data_ctx_f[0]['unit_amount'], 4.25)
 
     def test_analytic_line_read_override(self):
         # Cases for not rounding:

--- a/hr_timesheet_rounded/views/account_analytic_line.xml
+++ b/hr_timesheet_rounded/views/account_analytic_line.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
+  <record id="view_account_analytic_line_form_inherit" model="ir.ui.view">
+    <field name="name">account.analytic.line.form.inherit</field>
+    <field name="model">account.analytic.line</field>
+    <field name="inherit_id" ref="analytic.view_account_analytic_line_form"/>
+    <field name="arch" type="xml">
+
+      <xpath expr="//field[@name='unit_amount']" position="after">
+          <field name="unit_amount_rounded" string="Time Rounded" widget="float_time"/>
+      </xpath>
+
+    </field>
+  </record>
+
   <record id="account_analytic_line_kanban_inherit" model="ir.ui.view">
     <field name="name">account.analytic.line.kanban.inherit</field>
     <field name="model">account.analytic.line</field>


### PR DESCRIPTION
I tried to make this thing a bit easier to understand, but would be great if someone with better knowledge of math language can assert unit and factor are the right terms for their usage. (or we can drop the commit if we don't care :smile: )

Suggestion :
Rename the module sale_timesheet_rounded, to make it obvious what this module is about, because we definitely don't want to round the timesheets in hr related modules.
